### PR TITLE
Hotfix/fix path and nuget v2

### DIFF
--- a/src/NuGet/ConfigHelper.cs
+++ b/src/NuGet/ConfigHelper.cs
@@ -66,6 +66,7 @@ namespace CnSharp.VisualStudio.NuPack.NuGet
     {
         public string Url { get; set; }
         public string ApiKey { get; set; }
+        public string UserName { get; set; }
     }
 
     public class NuGetConfig

--- a/src/NuGet/DeployWizard.Designer.cs
+++ b/src/NuGet/DeployWizard.Designer.cs
@@ -341,7 +341,7 @@
             // 
             // textBoxLogin
             // 
-            this.textBoxLogin.Location = new System.Drawing.Point(36, 264);
+            this.textBoxLogin.Location = new System.Drawing.Point(36, 256);
             this.textBoxLogin.Name = "textBoxLogin";
             this.textBoxLogin.Size = new System.Drawing.Size(278, 23);
             this.textBoxLogin.TabIndex = 9;

--- a/src/NuGet/DeployWizard.Designer.cs
+++ b/src/NuGet/DeployWizard.Designer.cs
@@ -51,12 +51,16 @@
             this.wizardPage1 = new AeroWizard.WizardPage();
             this.chkSyncDep = new System.Windows.Forms.CheckBox();
             this.wizardPage2 = new AeroWizard.WizardPage();
+            this.chkIncludeReferencedProjects = new System.Windows.Forms.CheckBox();
             this.wizardPage3 = new AeroWizard.WizardPage();
+            this.checkBoxNugetLogin = new System.Windows.Forms.CheckBox();
             this.chkRemember = new System.Windows.Forms.CheckBox();
             this.errorProvider = new System.Windows.Forms.ErrorProvider(this.components);
             this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.folderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
-            this.chkIncludeReferencedProjects = new System.Windows.Forms.CheckBox();
+            this.textBoxLogin = new System.Windows.Forms.TextBox();
+            this.labelLogin = new System.Windows.Forms.Label();
+            this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
             ((System.ComponentModel.ISupportInitialize)(this.stepWizardControl)).BeginInit();
             this.wizardPage1.SuspendLayout();
             this.wizardPage2.SuspendLayout();
@@ -194,7 +198,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(33, 106);
+            this.label2.Location = new System.Drawing.Point(33, 90);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(50, 15);
             this.label2.TabIndex = 6;
@@ -202,7 +206,7 @@
             // 
             // txtKey
             // 
-            this.txtKey.Location = new System.Drawing.Point(36, 158);
+            this.txtKey.Location = new System.Drawing.Point(36, 122);
             this.txtKey.Name = "txtKey";
             this.txtKey.PasswordChar = '*';
             this.txtKey.Size = new System.Drawing.Size(278, 23);
@@ -278,8 +282,21 @@
             this.wizardPage2.TabIndex = 3;
             this.wizardPage2.Text = "Pack Settings";
             // 
+            // chkIncludeReferencedProjects
+            // 
+            this.chkIncludeReferencedProjects.AutoSize = true;
+            this.chkIncludeReferencedProjects.Location = new System.Drawing.Point(40, 231);
+            this.chkIncludeReferencedProjects.Name = "chkIncludeReferencedProjects";
+            this.chkIncludeReferencedProjects.Size = new System.Drawing.Size(166, 19);
+            this.chkIncludeReferencedProjects.TabIndex = 21;
+            this.chkIncludeReferencedProjects.Text = "IncludeReferencedProjects";
+            this.chkIncludeReferencedProjects.UseVisualStyleBackColor = true;
+            // 
             // wizardPage3
             // 
+            this.wizardPage3.Controls.Add(this.labelLogin);
+            this.wizardPage3.Controls.Add(this.textBoxLogin);
+            this.wizardPage3.Controls.Add(this.checkBoxNugetLogin);
             this.wizardPage3.Controls.Add(this.chkRemember);
             this.wizardPage3.Controls.Add(this.label1);
             this.wizardPage3.Controls.Add(this.sourceBox);
@@ -292,10 +309,21 @@
             this.wizardPage3.TabIndex = 4;
             this.wizardPage3.Text = "Deploy";
             // 
+            // checkBoxNugetLogin
+            // 
+            this.checkBoxNugetLogin.AutoSize = true;
+            this.checkBoxNugetLogin.Location = new System.Drawing.Point(36, 177);
+            this.checkBoxNugetLogin.Name = "checkBoxNugetLogin";
+            this.checkBoxNugetLogin.Size = new System.Drawing.Size(128, 19);
+            this.checkBoxNugetLogin.TabIndex = 8;
+            this.checkBoxNugetLogin.Text = "Use NuGet V2 login";
+            this.checkBoxNugetLogin.UseVisualStyleBackColor = true;
+            this.checkBoxNugetLogin.CheckedChanged += new System.EventHandler(this.checkBoxNugetLogin_CheckedChanged);
+            // 
             // chkRemember
             // 
             this.chkRemember.AutoSize = true;
-            this.chkRemember.Location = new System.Drawing.Point(36, 224);
+            this.chkRemember.Location = new System.Drawing.Point(337, 126);
             this.chkRemember.Name = "chkRemember";
             this.chkRemember.Size = new System.Drawing.Size(94, 19);
             this.chkRemember.TabIndex = 7;
@@ -311,15 +339,23 @@
             this.openFileDialog.FileName = "nuget.exe";
             this.openFileDialog.Title = "Open nuget.exe";
             // 
-            // chkIncludeReferencedProjects
+            // textBoxLogin
             // 
-            this.chkIncludeReferencedProjects.AutoSize = true;
-            this.chkIncludeReferencedProjects.Location = new System.Drawing.Point(40, 231);
-            this.chkIncludeReferencedProjects.Name = "chkIncludeReferencedProjects";
-            this.chkIncludeReferencedProjects.Size = new System.Drawing.Size(166, 19);
-            this.chkIncludeReferencedProjects.TabIndex = 21;
-            this.chkIncludeReferencedProjects.Text = "IncludeReferencedProjects";
-            this.chkIncludeReferencedProjects.UseVisualStyleBackColor = true;
+            this.textBoxLogin.Location = new System.Drawing.Point(36, 264);
+            this.textBoxLogin.Name = "textBoxLogin";
+            this.textBoxLogin.Size = new System.Drawing.Size(278, 23);
+            this.textBoxLogin.TabIndex = 9;
+            this.textBoxLogin.Visible = false;
+            // 
+            // labelLogin
+            // 
+            this.labelLogin.AutoSize = true;
+            this.labelLogin.Location = new System.Drawing.Point(33, 227);
+            this.labelLogin.Name = "labelLogin";
+            this.labelLogin.Size = new System.Drawing.Size(40, 15);
+            this.labelLogin.TabIndex = 28;
+            this.labelLogin.Text = "Login:";
+            this.labelLogin.Visible = false;
             // 
             // DeployWizard
             // 
@@ -374,5 +410,9 @@
         private System.Windows.Forms.CheckBox chkRemember;
         private System.Windows.Forms.CheckBox chkSyncDep;
         private System.Windows.Forms.CheckBox chkIncludeReferencedProjects;
+        private System.Windows.Forms.CheckBox checkBoxNugetLogin;
+        private System.Windows.Forms.TextBox textBoxLogin;
+        private System.Windows.Forms.Label labelLogin;
+        private System.ComponentModel.BackgroundWorker backgroundWorker1;
     }
 }

--- a/src/NuGet/DeployWizard.cs
+++ b/src/NuGet/DeployWizard.cs
@@ -293,6 +293,12 @@ namespace CnSharp.VisualStudio.NuPack.NuGet
                 var dir = _releaseDir;
                 if (!dir.EndsWith("\\"))
                     dir += "\\";
+                if (checkBoxNugetLogin.Checked)
+                {
+                    script.AppendFormat(@"""{0}"" sources Add -Name ""{1}"" -Source ""{2}"" -Username ""{3}"" -Password ""{4}""", nugetExe, url, url, textBoxLogin.Text, txtKey.Text);
+                    script.AppendFormat(@" || ""{0}"" sources Update -Name ""{1}"" -Source ""{2}"" -Username ""{3}"" -Password ""{4}""", nugetExe, url, url, textBoxLogin.Text, txtKey.Text);
+                    script.AppendLine();
+                }
                 script.AppendFormat(@"""{0}"" push ""{1}*.nupkg"" -source {2} {3}", nugetExe, dir, url, txtKey.Text);
             }
 
@@ -387,7 +393,10 @@ namespace CnSharp.VisualStudio.NuPack.NuGet
             var nugetExePath = txtNugetPath.Text.Trim();
             _nuGetConfig.NugetPath = nugetExePath;
             if (url.Length > 0)
-                _nuGetConfig.AddOrUpdateSource(new NuGetSource {Url = url, ApiKey = chkRemember.Checked ?  txtKey.Text : null});
+            {
+                _nuGetConfig.AddOrUpdateSource(new NuGetSource {Url = url, ApiKey = chkRemember.Checked ?  txtKey.Text : null,
+                    UserName = checkBoxNugetLogin.Checked ? textBoxLogin.Text : null});
+            }
             _nuGetConfig.Save();
         }
 
@@ -419,6 +428,14 @@ namespace CnSharp.VisualStudio.NuPack.NuGet
                 }
             }
             return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void checkBoxNugetLogin_CheckedChanged(object sender, EventArgs e)
+        {
+            var check = sender as CheckBox;
+
+            textBoxLogin.Visible = check.Checked;
+            labelLogin.Visible = check.Checked;
         }
     }
 }

--- a/src/NuGet/DeployWizard.cs
+++ b/src/NuGet/DeployWizard.cs
@@ -293,7 +293,7 @@ namespace CnSharp.VisualStudio.NuPack.NuGet
                 var dir = _releaseDir;
                 if (!dir.EndsWith("\\"))
                     dir += "\\";
-                script.AppendFormat(@"{0} push ""{1}*.nupkg"" -source {2} {3}", nugetExe, dir, url, txtKey.Text);
+                script.AppendFormat(@"""{0}"" push ""{1}*.nupkg"" -source {2} {3}", nugetExe, dir, url, txtKey.Text);
             }
 
             RunCmd(script.ToString());
@@ -420,7 +420,5 @@ namespace CnSharp.VisualStudio.NuPack.NuGet
             }
             return base.ProcessCmdKey(ref msg, keyData);
         }
-
-      
     }
 }

--- a/src/NuGet/DeployWizard.cs
+++ b/src/NuGet/DeployWizard.cs
@@ -415,6 +415,8 @@ namespace CnSharp.VisualStudio.NuPack.NuGet
             var source = _nuGetConfig.Sources.FirstOrDefault(m => m.Url == url);
             txtKey.Text = source?.ApiKey ?? string.Empty;
             chkRemember.Checked = txtKey.Text.Length > 0;
+            textBoxLogin.Text = source?.UserName;
+            checkBoxNugetLogin.Checked = textBoxLogin.Text.Length > 0;
         }
 
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)

--- a/src/NuGet/DeployWizard.resx
+++ b/src/NuGet/DeployWizard.resx
@@ -1818,4 +1818,7 @@
   <metadata name="folderBrowserDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>292, 18</value>
   </metadata>
+  <metadata name="backgroundWorker1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>455, 18</value>
+  </metadata>
 </root>

--- a/src/NuPack.csproj
+++ b/src/NuPack.csproj
@@ -283,9 +283,8 @@
     <Reference Include="VSLangProj80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="VsSharp, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31e1bdd79b8e5ae1, processorArchitecture=MSIL">
-      <HintPath>packages\VsSharp.1.2\lib\net35\VsSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="VsSharp, Version=1.1.1.0, Culture=neutral, PublicKeyToken=31e1bdd79b8e5ae1, processorArchitecture=MSIL">
+      <HintPath>packages\VsSharp.1.1.1\lib\net35\VsSharp.dll</HintPath>
     </Reference>
     <Reference Include="VsWebSite.Interop, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/src/NuPack.sln
+++ b/src/NuPack.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1CAC44E8-033D-416A-AD8B-C2A129774D9D}"
 	ProjectSection(SolutionItems) = preProject
@@ -13,6 +13,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTest", "..\UnitTest\UnitTest.csproj", "{2256B27A-40F1-40B7-A101-E2413AA04B5B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FormTests", "..\tests\FormTests\FormTests.csproj", "{D474AEE8-023F-478A-96C5-288D924A128A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsFormsApp1", "..\WindowsFormsApp1\WindowsFormsApp1.csproj", "{B7E21BEA-5463-4EAD-99B9-FD664383A907}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,6 +34,10 @@ Global
 		{D474AEE8-023F-478A-96C5-288D924A128A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D474AEE8-023F-478A-96C5-288D924A128A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D474AEE8-023F-478A-96C5-288D924A128A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NuPack.sln
+++ b/src/NuPack.sln
@@ -14,8 +14,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTest", "..\UnitTest\Uni
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FormTests", "..\tests\FormTests\FormTests.csproj", "{D474AEE8-023F-478A-96C5-288D924A128A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowsFormsApp1", "..\WindowsFormsApp1\WindowsFormsApp1.csproj", "{B7E21BEA-5463-4EAD-99B9-FD664383A907}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,10 +32,6 @@ Global
 		{D474AEE8-023F-478A-96C5-288D924A128A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D474AEE8-023F-478A-96C5-288D924A128A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D474AEE8-023F-478A-96C5-288D924A128A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B7E21BEA-5463-4EAD-99B9-FD664383A907}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/packages.config
+++ b/src/packages.config
@@ -21,5 +21,5 @@
   <package id="Microsoft.VisualStudio.Utilities" version="14.3.25407" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net45" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net45" developmentDependency="true" />
-  <package id="VsSharp" version="1.2" targetFramework="net45" />
+  <package id="VsSharp" version="1.1.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hello sir,

This hotfix branch contains fixes for both issues #5 and #4 ! Feel free to test them and review them.
You can delete all the changes but the ones in the code, since I had to downgrade a package that you were locally referencing in order to compile properly (the package was not found on NuGet, I assumed you wrote it).

The changes :

- You can now point to a path containing spaces for the nuget.exe, it won't crash at publish time
- You can now use NuGet V2 login system

For the NuGet login, it basically writes your credentials on the nuget.config file, and uses them whenever your push to the specified repository. It fixes the fact that the VS console is non interactive, not allowing you to enter your credentials directly.

Regards