### PR TITLE
fix error on date for Release Notes

### DIFF
--- a/src/release_notes.txt
+++ b/src/release_notes.txt
@@ -1,4 +1,4 @@
-﻿### V2.0.1 4/23/2017
+﻿### V2.0.1 4/23/2018
 * Add auto increment version number feature.
 
 ### V2.0 4/21/2017


### PR DESCRIPTION
Hi, I think that the year of the last change of the release note should be 2018